### PR TITLE
Discussion: Customized Strategy

### DIFF
--- a/packages/react-sunbeam/package.json
+++ b/packages/react-sunbeam/package.json
@@ -17,6 +17,7 @@
         "build": "yarn build:es && yarn build:cjs",
         "build:es": "tsc --outDir dist/es",
         "build:cjs": "tsc --outDir dist/cjs --module CommonJS",
+        "build:esnext": "tsc --outDir dist/esnext --module esnext --removeComments --target ES2020",
         "clean": "rimraf dist",
         "dev": "concurrently 'yarn build:es --watch' 'yarn build:cjs --watch' -n ES2017,CommonJS -c cyan,magenta",
         "lint": "eslint ./src --ext .ts,.tsx",

--- a/packages/react-sunbeam/src/focus/FocusManager.ts
+++ b/packages/react-sunbeam/src/focus/FocusManager.ts
@@ -1,4 +1,4 @@
-import { FocusableTreeNode, FocusPath } from "./types"
+import { FocusableTreeNode, FocusPath, FocusPathValidator } from "./types"
 import { getNodeByPath, getPathToNode, validateAndFixFocusPathIfNeeded } from "./FocusableTreeUtils"
 import { Direction } from "../spatialNavigation"
 import findBestCandidateAmongSiblingsOf from "./strategies/bestCandidateAmongSiblings"
@@ -7,11 +7,13 @@ import { GetPreferredChildFn } from "./types"
 interface Options {
     initialFocusPath: FocusPath
     strategy?: GetPreferredChildFn
+    validateFocusPath?: FocusPathValidator
 }
 
 const defaultOptions: Options = {
     initialFocusPath: [],
     strategy: findBestCandidateAmongSiblingsOf,
+    validateFocusPath: validateAndFixFocusPathIfNeeded,
 }
 
 export class FocusManager {
@@ -22,11 +24,13 @@ export class FocusManager {
     private focusableRoot: FocusableTreeNode | undefined
     private subscribers: Set<Function>
     private strategy: GetPreferredChildFn
+    private validateFocusPath: FocusPathValidator
 
     public constructor(options: Options = defaultOptions) {
         this.focusPath = options.initialFocusPath
         this.strategy = options.strategy || (defaultOptions.strategy as GetPreferredChildFn)
         this.subscribers = new Set()
+        this.validateFocusPath = options.validateFocusPath || validateAndFixFocusPathIfNeeded
     }
 
     public setFocusableRoot(focusableRoot: FocusableTreeNode): void {
@@ -54,7 +58,7 @@ export class FocusManager {
             return
         }
 
-        const fixedFocusPath = validateAndFixFocusPathIfNeeded(this.focusPath, this.focusableRoot)
+        const fixedFocusPath = this.validateFocusPath(this.focusPath, this.focusableRoot)
         if (fixedFocusPath) {
             this.setFocus(fixedFocusPath)
         }

--- a/packages/react-sunbeam/src/focus/index.ts
+++ b/packages/react-sunbeam/src/focus/index.ts
@@ -11,6 +11,7 @@ export { useFocusable } from "./hooks/useFocusable"
 export { FocusableTreeContext } from "./FocusableTreeContext"
 
 export type FocusableTreeNode = FocusableTreeNode
+// export type FocusableNodesMap = FocusableNodesMap
 
 // eslint-disable-next-line @typescript-eslint/camelcase
 export function unstable_defaultGetPreferredChildOnFocusReceive({

--- a/packages/react-sunbeam/src/focus/index.ts
+++ b/packages/react-sunbeam/src/focus/index.ts
@@ -2,12 +2,13 @@ import getPreferredNode from "./getPreferredNode"
 import { FocusableTreeNode } from "./types"
 import { Direction } from "../spatialNavigation"
 
-export { FocusEvent } from "./types"
+export { FocusEvent, FocusableNodesMap } from "./types"
 export { FocusManager } from "./FocusManager"
 export { Focusable } from "./components/Focusable"
 export { SunbeamProvider } from "./components/SunbeamProvider"
 export { useSunbeam } from "./hooks/useSunbeam"
 export { useFocusable } from "./hooks/useFocusable"
+export { FocusableTreeContext } from "./FocusableTreeContext"
 
 export type FocusableTreeNode = FocusableTreeNode
 

--- a/packages/react-sunbeam/src/focus/strategies/bestCandidateAmongSiblings.tsx
+++ b/packages/react-sunbeam/src/focus/strategies/bestCandidateAmongSiblings.tsx
@@ -1,0 +1,60 @@
+import { FocusableTreeNode } from "../types"
+import { Direction, getBestCandidate } from "../../spatialNavigation"
+import { boxesWithinFrustumOfOrigin } from "../../spatialNavigation/frustumFilteringUtils"
+import { getSiblings } from "../FocusableTreeUtils"
+
+export default function findBestDefaultStrategy(
+    focusOrigin?: FocusableTreeNode,
+    direction?: Direction
+): FocusableTreeNode | undefined {
+    if (!focusOrigin || !direction) {
+        return
+    }
+    return findBestCandidateAmongSiblingsOf(focusOrigin, focusOrigin, direction)
+}
+
+export function findBestCandidateAmongSiblingsOf(
+    treeNode: FocusableTreeNode,
+    focusOrigin: FocusableTreeNode,
+    direction: Direction
+): FocusableTreeNode | undefined {
+    // 2. Search for the best candidate among siblings of the current focusOrigin
+    // If not found repeat the same process for the parent FocusableNode's siblings
+    // until either the candidate is found or the FocusableRootNode is reached
+    const focusableSiblings = getSiblings(treeNode)
+
+    const siblingBoxes = focusableSiblings.map(node => node.getBoundingBox())
+    const siblingsWithinFrustum = boxesWithinFrustumOfOrigin(siblingBoxes, treeNode.getBoundingBox(), direction)
+    const bestCandidateBox = getBestCandidate(focusOrigin.getBoundingBox(), siblingsWithinFrustum, direction)
+    if (!bestCandidateBox) {
+        const parent = treeNode.getParent()
+        // Best candidate is not found, so the focus doesn't move
+        if (!parent) return
+
+        return findBestCandidateAmongSiblingsOf(parent, focusOrigin, direction)
+    }
+
+    const bestCandidateIndex = siblingBoxes.indexOf(bestCandidateBox)
+    let bestCandidateNode = focusableSiblings[bestCandidateIndex]
+
+    // 3. Once the best candidate is found recursively ask it
+    // for the preferredChild FocusableNode until a leaf node is reached
+    while (bestCandidateNode) {
+        if (bestCandidateNode.getChildren().size === 0) {
+            // we found the bestCandidate
+            break
+        }
+
+        const preferredChild = bestCandidateNode.getPreferredChild(focusOrigin, direction)
+        if (!preferredChild) {
+            throw new Error(
+                "`focusableTreeNode.getPreferredChild()` should " +
+                    "never return `undefined` when it has at least 1 child"
+            )
+        }
+
+        bestCandidateNode = preferredChild
+    }
+
+    return bestCandidateNode
+}

--- a/packages/react-sunbeam/src/focus/types.ts
+++ b/packages/react-sunbeam/src/focus/types.ts
@@ -22,6 +22,8 @@ export type FocusableTreeNode = {
     getPreferredChild: GetPreferredChildFn
 }
 
+export type FocusPathValidator = (focusPath: FocusPath, treeRoot: FocusableTreeNode) => FocusPath | null
+
 export type FocusableNodesMap = Map<string, FocusableTreeNode>
 
 export type GetChildrenFn = () => FocusableNodesMap

--- a/packages/react-sunbeam/src/index.ts
+++ b/packages/react-sunbeam/src/index.ts
@@ -8,6 +8,7 @@ export {
     FocusEvent,
     // eslint-disable-next-line @typescript-eslint/camelcase
     unstable_defaultGetPreferredChildOnFocusReceive,
+    FocusableTreeContext,
 } from "./focus"
 export { Direction } from "./spatialNavigation"
 export { KeyPressManager, KeyPressListener } from "./keyPressManagement"

--- a/packages/react-sunbeam/src/index.ts
+++ b/packages/react-sunbeam/src/index.ts
@@ -9,6 +9,7 @@ export {
     // eslint-disable-next-line @typescript-eslint/camelcase
     unstable_defaultGetPreferredChildOnFocusReceive,
     FocusableTreeContext,
+    FocusableNodesMap,
 } from "./focus"
 export { Direction } from "./spatialNavigation"
 export { KeyPressManager, KeyPressListener } from "./keyPressManagement"

--- a/packages/react-sunbeam/src/index.ts
+++ b/packages/react-sunbeam/src/index.ts
@@ -11,3 +11,4 @@ export {
 } from "./focus"
 export { Direction } from "./spatialNavigation"
 export { KeyPressManager, KeyPressListener } from "./keyPressManagement"
+export { getPathToNode } from "./focus/FocusableTreeUtils"

--- a/packages/strategy-demo/AutoFocus.tsx
+++ b/packages/strategy-demo/AutoFocus.tsx
@@ -72,7 +72,6 @@ export default function AutoFocusContainer({ children, focusKey }: ContainerProp
         const first = sorted.find(node => getFirstFocusableChild(node, direction))
         if (first && setFocus) {
             const path = getPathToNode(first)
-            console.log("Setting Focus to", path)
             setFocus(path)
         }
     }, [preContext.parentFocusableNode, focusableChildrenRef.current, setFocus])

--- a/packages/strategy-demo/AutoFocus.tsx
+++ b/packages/strategy-demo/AutoFocus.tsx
@@ -1,0 +1,39 @@
+import * as React from "react"
+import { useContext, useEffect, useRef, useMemo } from "react"
+import { FocusableTreeContext, Focusable, FocusableTreeNode, useSunbeam, getPathToNode } from "../react-sunbeam"
+
+type ContainerProps = {
+    children: React.ReactNode
+    focusKey: string
+    style?: React.CSSProperties
+}
+
+export default function AutoFocusContainer({ children, focusKey, ...rest }: ContainerProps) {
+    const realFocusKey = focusKey ? `#AutoFocus#${focusKey}` : undefined
+    return (
+        <Focusable focusKey={realFocusKey} {...rest}>
+            <AutoFocusTrigger />
+            {children}
+        </Focusable>
+    )
+}
+
+export function AutoFocusTrigger() {
+    const sunbeam = useSunbeam()
+    const { parentFocusableNode } = useContext(FocusableTreeContext)
+
+    useEffect(() => {
+        const children = parentFocusableNode.getChildren()
+        if (children.size === 0) {
+            return
+        }
+        const nextChild = parentFocusableNode.getPreferredChild()
+        if (nextChild) {
+            const targetFocusPath = getPathToNode(nextChild)
+            if (sunbeam && sunbeam.setFocus && targetFocusPath) {
+                sunbeam.setFocus(targetFocusPath)
+            }
+        }
+    }, [])
+    return null
+}

--- a/packages/strategy-demo/FocusIgnore.tsx
+++ b/packages/strategy-demo/FocusIgnore.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+import { Focusable } from "../react-sunbeam/dist/es"
+
+type Props = {
+    active: boolean
+    children?: React.ReactNode
+    focusKey: string
+    style?: React.CSSProperties
+}
+
+export default function IgnoreFocus({ focusKey, active, children, ...rest }: Props) {
+    const fullFocusKey = active ? `#ignore#active#${focusKey}` : `#ignore#${focusKey}`
+
+    return (
+        <Focusable focusKey={fullFocusKey} {...rest}>
+            {children}
+        </Focusable>
+    )
+}

--- a/packages/strategy-demo/FocusLock.tsx
+++ b/packages/strategy-demo/FocusLock.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+import { useRef } from "react"
+import { useFocusable } from "../react-sunbeam"
+
+interface Props {
+    children?: React.ReactNode
+    focusKey: string
+}
+
+export default function FocusLock({ focusKey, children }: Props) {
+    const elementRef = useRef<HTMLDivElement>(null)
+    const fullFocusKey = `#lock#${focusKey}`
+    const { focused, path } = useFocusable({
+        focusKey: fullFocusKey,
+        elementRef,
+    })
+    return <div ref={elementRef}>{children}</div>
+}

--- a/packages/strategy-demo/FocusLock.tsx
+++ b/packages/strategy-demo/FocusLock.tsx
@@ -5,11 +5,11 @@ type Props = {
     children?: React.ReactNode
     focusKey: string
     style?: React.CSSProperties
+    disabled?: boolean
 }
 
-export default function FocusLock({ focusKey, children, ...rest }: Props) {
-    const fullFocusKey = `#FocusLock#${focusKey}`
-
+export default function FocusLock({ focusKey, children, disabled, ...rest }: Props) {
+    const fullFocusKey = disabled ? focusKey : `#FocusLock#${focusKey}`
     return (
         <Focusable focusKey={fullFocusKey} {...rest}>
             {children}

--- a/packages/strategy-demo/FocusLock.tsx
+++ b/packages/strategy-demo/FocusLock.tsx
@@ -1,18 +1,18 @@
 import * as React from "react"
-import { useRef } from "react"
-import { useFocusable } from "../react-sunbeam"
+import { Focusable } from "../react-sunbeam"
 
-interface Props {
+type Props = {
     children?: React.ReactNode
     focusKey: string
+    style?: React.CSSProperties
 }
 
-export default function FocusLock({ focusKey, children }: Props) {
-    const elementRef = useRef<HTMLDivElement>(null)
-    const fullFocusKey = `#lock#${focusKey}`
-    const { focused, path } = useFocusable({
-        focusKey: fullFocusKey,
-        elementRef,
-    })
-    return <div ref={elementRef}>{children}</div>
+export default function FocusLock({ focusKey, children, ...rest }: Props) {
+    const fullFocusKey = `#FocusLock#${focusKey}`
+
+    return (
+        <Focusable focusKey={fullFocusKey} {...rest}>
+            {children}
+        </Focusable>
+    )
 }

--- a/packages/strategy-demo/FocusableItem.tsx
+++ b/packages/strategy-demo/FocusableItem.tsx
@@ -1,0 +1,41 @@
+import * as React from "react"
+import { useRef, useCallback } from "react"
+import { useFocusable, useSunbeam, FocusEvent, KeyPressListener } from "../react-sunbeam"
+
+type Props = {
+    children?: React.ReactNode | string
+    style?: React.CSSProperties | ((focused: boolean) => React.CSSProperties)
+    focusKey: string
+    onKeyPress?: KeyPressListener
+    onFocus?: (event: FocusEvent) => void
+    onBlur?: (event: FocusEvent) => void
+}
+
+/**
+ * This is an example of how an abstraction for a "focusable" element can look like in your app.
+ * It uses several primitives provided by `react-sunbeam` to create a component specifically tailored
+ * to the app. For example `FocusableItem` uses "tap-to-focus" functionality because the app requires it
+ * even though `react-sunbeam` doesn't implement it out-of-the-box
+ */
+export function FocusableItem({ children, style, focusKey, onKeyPress, onFocus, onBlur }: Props) {
+    const elementRef = useRef<HTMLDivElement>(null)
+    const { focused, path } = useFocusable({
+        focusKey,
+        elementRef,
+        onFocus,
+        onBlur,
+        onKeyPress,
+    })
+    const sunbeamContextValue = useSunbeam()
+    const setFocus = sunbeamContextValue ? sunbeamContextValue.setFocus : undefined
+
+    const handleClick = useCallback(() => {
+        if (setFocus) setFocus(path)
+    }, [path])
+
+    return (
+        <div ref={elementRef} style={typeof style === "function" ? style(focused) : style} onClick={handleClick}>
+            {children}
+        </div>
+    )
+}

--- a/packages/strategy-demo/HorizontalList.tsx
+++ b/packages/strategy-demo/HorizontalList.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+import { Focusable } from "../react-sunbeam"
+
+type Props = {
+    children?: React.ReactNode
+    focusKey: string
+    style?: React.CSSProperties
+}
+
+export default function HorizontalList({ focusKey, children, ...rest }: Props) {
+    const fullFocusKey = `#horizontal#${focusKey}`
+
+    return (
+        <Focusable focusKey={fullFocusKey} {...rest}>
+            {children}
+        </Focusable>
+    )
+}

--- a/packages/strategy-demo/StyledFocusItem.tsx
+++ b/packages/strategy-demo/StyledFocusItem.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import { FocusableItem } from "./FocusableItem"
+import { FocusEvent } from "../react-sunbeam"
+
+type Props = {
+    focusKey: string
+    onFocus?: (event: FocusEvent) => void
+    onBlur?: (event: FocusEvent) => void
+}
+
+export default function StyledFocusItem({ focusKey, onFocus, onBlur }: Props) {
+    return (
+        <FocusableItem
+            focusKey={focusKey}
+            style={focused => ({
+                border: focused ? "4px solid cyan" : "4px solid transparent",
+                borderRadius: "50%",
+                transition: "border-color 100ms ease-out",
+            })}
+            onFocus={onFocus}
+            onBlur={onBlur}
+        >
+            {focusKey}
+        </FocusableItem>
+    )
+}

--- a/packages/strategy-demo/VerticalList.tsx
+++ b/packages/strategy-demo/VerticalList.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+import { Focusable } from "../react-sunbeam"
+
+type Props = {
+    children?: React.ReactNode
+    focusKey: string
+    style?: React.CSSProperties
+}
+
+export default function VerticalList({ focusKey, children, ...rest }: Props) {
+    const fullFocusKey = `#vertical#${focusKey}`
+
+    return (
+        <Focusable focusKey={fullFocusKey} {...rest}>
+            {children}
+        </Focusable>
+    )
+}

--- a/packages/strategy-demo/VerticalList.tsx
+++ b/packages/strategy-demo/VerticalList.tsx
@@ -1,15 +1,25 @@
 import * as React from "react"
-import { Focusable } from "../react-sunbeam"
+import { Focusable, KeyPressListener } from "../react-sunbeam"
+import { useCallback } from "react"
 
 type Props = {
     children?: React.ReactNode
     focusKey: string
     style?: React.CSSProperties
+    onKeyPress?: KeyPressListener
 }
 
 export default function VerticalList({ focusKey, children, ...rest }: Props) {
     const fullFocusKey = `#vertical#${focusKey}`
-
+    // const onFocusReceive = useCallback(({ focusableChildren, focusOrigin, direction }) => {
+    //     console.log("onFocusReceive!")
+    //     debugger
+    // }, [])
+    // const onFocus = useCallback((a, b) => {
+    //     console.log(a)
+    //     console.log(b)
+    //     debugger
+    // }, [])
     return (
         <Focusable focusKey={fullFocusKey} {...rest}>
             {children}

--- a/packages/strategy-demo/customStrategy.tsx
+++ b/packages/strategy-demo/customStrategy.tsx
@@ -1,0 +1,131 @@
+import { FocusableTreeNode, Direction, getPathToNode } from "../react-sunbeam"
+
+const verticalDirections = [Direction.UP, Direction.DOWN]
+const horizontalDirections = [Direction.RIGHT, Direction.LEFT]
+const forwardDirections = [Direction.DOWN, Direction.RIGHT]
+const backwardDirections = [Direction.UP, Direction.LEFT]
+
+export default function findNestFocusTarget(
+    focusOrigin?: FocusableTreeNode,
+    direction?: Direction
+): FocusableTreeNode | undefined {
+    if (!focusOrigin || !direction) {
+        return
+    }
+    // 1. Find the first Parent that is Relevant for the current Direction (Vertical / Horizontal)
+    const found = searchFrom(focusOrigin, focusOrigin, direction)
+    return found
+}
+
+function searchFrom(
+    start: FocusableTreeNode,
+    origin: FocusableTreeNode,
+    direction: Direction
+): FocusableTreeNode | undefined {
+    const directionParent = getDirectionParent(start, direction)
+    if (!directionParent) {
+        return
+    }
+    const focusTarget = getNextChildWithinParent(directionParent, origin, direction)
+    if (!focusTarget) {
+        return searchFrom(directionParent, origin, direction)
+    }
+    const focusableLeaf = getFirstFocusableChild(focusTarget, direction)
+    return focusableLeaf
+}
+
+function getDirectionParent(node: FocusableTreeNode, direction: Direction): FocusableTreeNode | null {
+    if (horizontalDirections.indexOf(direction) > -1) {
+        return getHorizontalParent(node)
+    } else if (verticalDirections.indexOf(direction) > -1) {
+        return getVerticalParent(node)
+    }
+    throw new Error(`Cant find parent for Direction ${direction}`)
+}
+
+function getHorizontalParent(node: FocusableTreeNode): FocusableTreeNode | null {
+    const parent = node.getParent()
+    if (!parent) {
+        return null
+    }
+    if (allowHorizontal(parent)) {
+        return parent
+    }
+    return getHorizontalParent(parent)
+}
+
+function getVerticalParent(node: FocusableTreeNode): FocusableTreeNode | null {
+    const parent = node.getParent()
+    if (!parent) {
+        return null
+    }
+    if (allowVertical(parent)) {
+        return parent
+    }
+    return getVerticalParent(parent)
+}
+
+function allowHorizontal(parent: FocusableTreeNode) {
+    return parent.focusKey.indexOf("#horizontal#") === 0
+}
+
+function allowVertical(parent: FocusableTreeNode) {
+    return parent.focusKey.indexOf("#vertical#") === 0
+}
+
+function getNextChildWithinParent(searchRoot: FocusableTreeNode, focusOrigin: FocusableTreeNode, direction: Direction) {
+    const currentPath = getPathToNode(focusOrigin)
+    const pathIndex = currentPath.indexOf(searchRoot.focusKey)
+    const sortedChildren = sortNodesForDirection(Array.from(searchRoot.getChildren().values()), direction)
+    const focusedChildKey = currentPath[pathIndex + 1]
+    const nodeToFocus = getNextFocusedNode(sortedChildren, focusedChildKey, direction)
+    return nodeToFocus
+}
+
+function sortNodesForDirection(children: Array<FocusableTreeNode>, direction: Direction) {
+    return children.sort((a, b) => {
+        const key = horizontalDirections.indexOf(direction) > -1 ? "left" : "top"
+        const aBox = a.getBoundingBox()
+        const bBox = b.getBoundingBox()
+        const aValue = aBox[key]
+        const bValue = bBox[key]
+        if (aValue < bValue) {
+            return -1
+        } else if (aValue > bValue) {
+            return 1
+        }
+        return 0
+    })
+}
+
+function isForward(direction: Direction) {
+    return forwardDirections.indexOf(direction) > -1
+}
+
+function getNextFocusedNode(children: Array<FocusableTreeNode>, startKey: string, direction: Direction) {
+    const modifier = isForward(direction) ? 1 : -1
+    const currentIndex = children.map(c => c.focusKey).indexOf(startKey)
+    const nextIndex = currentIndex + modifier
+    const nextElement = children[nextIndex]
+    return nextElement
+}
+
+function getFirstFocusableChild(node: FocusableTreeNode, direction: Direction): FocusableTreeNode {
+    if (isLeaf(node)) {
+        return node
+    }
+    const firstChild = getFirstChild(Array.from(node.getChildren().values()), direction)
+    if (!firstChild) {
+        return node
+    }
+    return getFirstFocusableChild(firstChild, direction)
+}
+
+function getFirstChild(children: Array<FocusableTreeNode>, direction: Direction): FocusableTreeNode | null {
+    const sortedChildren = sortNodesForDirection(children, direction)
+    return sortedChildren[0]
+}
+
+function isLeaf(node: FocusableTreeNode) {
+    return node.getChildren().size === 0
+}

--- a/packages/strategy-demo/customStrategy.tsx
+++ b/packages/strategy-demo/customStrategy.tsx
@@ -27,47 +27,37 @@ function searchFrom(
     origin: FocusableTreeNode,
     direction: Direction
 ): FocusableTreeNode | undefined {
-    const directionParent = getDirectionParent(start, direction)
+    const parent = start.getParent()
+    if (!parent) {
+        return
+    }
+    const directionParent = getDirectionParent(parent, direction)
     if (!directionParent) {
         return
     }
     const focusTarget = getNextChildWithinParent(directionParent, origin, direction)
     if (!focusTarget) {
+        if (directionParent === start || isFocusLock(directionParent)) {
+            return
+        }
         return searchFrom(directionParent, origin, direction)
     }
     const focusableLeaf = getFirstFocusableChild(focusTarget, direction)
     return focusableLeaf
 }
 
-function getDirectionParent(node: FocusableTreeNode, direction: Direction): FocusableTreeNode | null {
-    if (horizontalDirections.indexOf(direction) > -1) {
-        return getHorizontalParent(node)
-    } else if (verticalDirections.indexOf(direction) > -1) {
-        return getVerticalParent(node)
+function getDirectionParent(node: FocusableTreeNode, direction: Direction): FocusableTreeNode | undefined {
+    if (isHorizontalDirection(direction) && isHorizontalList(node)) {
+        return node
+    } else if (isVerticalDirection(direction) && isVerticalList(node)) {
+        return node
+    } else if (isFocusLock(node)) {
+        return node
     }
-    throw new Error(`Cant find parent for Direction ${direction}`)
-}
-
-function getHorizontalParent(node: FocusableTreeNode): FocusableTreeNode | null {
     const parent = node.getParent()
-    if (!parent) {
-        return null
+    if (parent) {
+        return getDirectionParent(parent, direction)
     }
-    if (isHorizontalList(parent)) {
-        return parent
-    }
-    return getHorizontalParent(parent)
-}
-
-function getVerticalParent(node: FocusableTreeNode): FocusableTreeNode | null {
-    const parent = node.getParent()
-    if (!parent) {
-        return null
-    }
-    if (isVerticalList(parent)) {
-        return parent
-    }
-    return getVerticalParent(parent)
 }
 
 function isHorizontalList(node: FocusableTreeNode) {
@@ -175,8 +165,8 @@ function flattenNodesForDirection(
             targets.push(node)
         } else if (shouldIgnore(node)) {
         } else if (
-            (isHorizontalList(node) && isHorizontalDirection(direction)) ||
-            (isVerticalList(node) && isVerticalDirection(direction)) ||
+            // (isHorizontalList(node) && isHorizontalDirection(direction)) ||
+            // (isVerticalList(node) && isVerticalDirection(direction)) ||
             isAutoFocus(node) ||
             isFocusLock(node) ||
             isIgnoreContainer(node)

--- a/packages/strategy-demo/index.html
+++ b/packages/strategy-demo/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>ReactSunbeam demo</title>
+    </head>
+    <style>
+        body {
+            margin: 0;
+        }
+    </style>
+    <body>
+        <div id="app"></div>
+        <script src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/strategy-demo/index.tsx
+++ b/packages/strategy-demo/index.tsx
@@ -1,13 +1,15 @@
 import * as React from "react"
-import { useCallback, useState } from "react"
+import { useCallback, useState, useRef } from "react"
 import { render } from "react-dom"
-import { FocusManager, SunbeamProvider, KeyPressManager } from "../react-sunbeam"
+import { FocusManager, SunbeamProvider, KeyPressManager, useFocusable, Focusable } from "../react-sunbeam"
 import Item from "./StyledFocusItem"
 import HorizontalList from "./HorizontalList"
 import VerticalList from "./VerticalList"
 // import FocusLock from "./FocusLock"
 import customStrategy from "./customStrategy"
 import AutoFocus from "./AutoFocus"
+import FocusLock from "./FocusLock"
+import FocusIgnore from "./FocusIgnore"
 
 const focusManager = new FocusManager({
     initialFocusPath: [
@@ -16,6 +18,12 @@ const focusManager = new FocusManager({
         "#horizontal#horizontal_list",
         "sub_horizontal_1",
     ],
+    // initialFocusPath: [
+    //     "#vertical#root_vertical",
+    //     "#vertical#vertical_list_1",
+    //     "#vertical#expandable-list",
+    //     "sub_item_1",
+    // ],
     strategy: customStrategy,
 })
 const keyPressManager = new KeyPressManager()
@@ -61,6 +69,9 @@ function App() {
 function AppBody() {
     const [added, setAdded] = useState(false)
     const toggleAdded = useCallback(() => setAdded(a => !a), [setAdded])
+    const [ignore, setIgnore] = useState(false)
+    const toggleIgnore = useCallback(() => setIgnore(a => !a), [setIgnore])
+
     return (
         <div
             style={{
@@ -69,6 +80,7 @@ function AppBody() {
             }}
         >
             <button onClick={toggleAdded}>Add Dynami</button>
+            <button onClick={toggleIgnore}>Ignore</button>
             <HorizontalList
                 focusKey="horizontal_list"
                 style={{ marginTop: "32px", marginLeft: "60px", display: "flex" }}
@@ -78,7 +90,7 @@ function AppBody() {
 
             <div style={{ marginTop: "94px" }}>
                 <VerticalList focusKey="vertical_list_1">
-                    <VerticalMainBody added={added} />
+                    <VerticalMainBody added={added} ignore={ignore} />
                 </VerticalList>
             </div>
         </div>
@@ -94,7 +106,7 @@ function HorizontalBody() {
     )
 }
 
-function VerticalMainBody({ added }: { added: boolean }) {
+function VerticalMainBody({ added, ignore }: { added: boolean; ignore: boolean }) {
     return (
         <>
             <Item focusKey="vertical_item_1" />
@@ -108,8 +120,20 @@ function VerticalMainBody({ added }: { added: boolean }) {
             >
                 <SubHorizontalBody />
             </HorizontalList>
+            <IgnoreSection ignore={ignore} />
             <Item focusKey="forth" />
         </>
+    )
+}
+
+function IgnoreSection({ ignore }: { ignore: boolean }) {
+    return (
+        <div style={{ color: ignore ? "#c2d5cc" : undefined }}>
+            <FocusIgnore active={ignore} focusKey="ignore-container">
+                <Item focusKey="ignore-1" />
+                <Item focusKey="ignore-2" />
+            </FocusIgnore>
+        </div>
     )
 }
 
@@ -126,19 +150,17 @@ function ExpandableSection() {
         <VerticalList focusKey="expandable-list" onKeyPress={onExpandablePress}>
             <Item focusKey="expandable" />
             {expanded && (
-                <AutoFocus focusKey="autofocus-subgroup" style={{ marginLeft: 20 }}>
-                    <Item focusKey="sub_item_1" />
-                    <Item focusKey="sub_item_2" />
-                    <Item focusKey="sub_item_3" />
-                </AutoFocus>
+                <FocusLock focusKey="my-only-lock">
+                    <AutoFocus focusKey="autofocus-subgroup" style={{ marginLeft: 20 }}>
+                        <Item focusKey="sub_item_1" />
+                        <Item focusKey="sub_item_2" />
+                        <Item focusKey="sub_item_3" />
+                    </AutoFocus>
+                </FocusLock>
             )}
         </VerticalList>
     )
 }
-
-// function ExpandableSectionChildren(){
-
-// }
 
 function SubHorizontalBody() {
     return (

--- a/packages/strategy-demo/index.tsx
+++ b/packages/strategy-demo/index.tsx
@@ -7,6 +7,7 @@ import HorizontalList from "./HorizontalList"
 import VerticalList from "./VerticalList"
 // import FocusLock from "./FocusLock"
 import customStrategy from "./customStrategy"
+import AutoFocus from "./AutoFocus"
 
 const focusManager = new FocusManager({
     initialFocusPath: [
@@ -50,8 +51,6 @@ render(
 )
 
 function App() {
-    const [expanded, setExpanded] = useState(false)
-
     return (
         <VerticalList focusKey="root_vertical">
             <AppBody />
@@ -100,7 +99,7 @@ function VerticalMainBody({ added }: { added: boolean }) {
         <>
             <Item focusKey="vertical_item_1" />
             <Item focusKey="vertical_item_2" />
-            <Item focusKey="expandable" />
+            <ExpandableSection />
             <Item focusKey="third" />
             {added && <Item focusKey="dynamically added" />}
             <HorizontalList
@@ -113,6 +112,33 @@ function VerticalMainBody({ added }: { added: boolean }) {
         </>
     )
 }
+
+function ExpandableSection() {
+    const [expanded, setExpanded] = useState(false)
+    const onExpandablePress = useCallback(event => {
+        if (event.key === "Enter") {
+            setExpanded(true)
+        } else if (event.key === "Backspace") {
+            setExpanded(false)
+        }
+    }, [])
+    return (
+        <VerticalList focusKey="expandable-list" onKeyPress={onExpandablePress}>
+            <Item focusKey="expandable" />
+            {expanded && (
+                <AutoFocus focusKey="autofocus-subgroup" style={{ marginLeft: 20 }}>
+                    <Item focusKey="sub_item_1" />
+                    <Item focusKey="sub_item_2" />
+                    <Item focusKey="sub_item_3" />
+                </AutoFocus>
+            )}
+        </VerticalList>
+    )
+}
+
+// function ExpandableSectionChildren(){
+
+// }
 
 function SubHorizontalBody() {
     return (

--- a/packages/strategy-demo/index.tsx
+++ b/packages/strategy-demo/index.tsx
@@ -83,13 +83,13 @@ function AppBody() {
             <button onClick={toggleIgnore}>Ignore</button>
             <HorizontalList
                 focusKey="horizontal_list"
-                style={{ marginTop: "32px", marginLeft: "60px", display: "flex" }}
+                style={{ marginTop: "32px", marginLeft: "60px", display: "flex", border: "1px solid blue" }}
             >
                 <HorizontalBody />
             </HorizontalList>
 
             <div style={{ marginTop: "94px" }}>
-                <VerticalList focusKey="vertical_list_1">
+                <VerticalList focusKey="vertical_list_1" style={{ border: "1px solid blue" }}>
                     <VerticalMainBody added={added} ignore={ignore} />
                 </VerticalList>
             </div>
@@ -111,12 +111,17 @@ function VerticalMainBody({ added, ignore }: { added: boolean; ignore: boolean }
         <>
             <Item focusKey="vertical_item_1" />
             <Item focusKey="vertical_item_2" />
+            <VerticalList focusKey="inner-vertical" style={{ border: "1px solid green" }}>
+                <Item focusKey="inner-vert-1" />
+                <Item focusKey="inner-vert-2" />
+            </VerticalList>
+
             <ExpandableSection />
             <Item focusKey="third" />
             {added && <Item focusKey="dynamically added" />}
             <HorizontalList
                 focusKey="horizontal_list"
-                style={{ marginTop: "16px", marginLeft: "60px", display: "flex" }}
+                style={{ marginTop: "16px", marginLeft: "60px", display: "flex", border: "1px solid blue" }}
             >
                 <SubHorizontalBody />
             </HorizontalList>
@@ -147,7 +152,7 @@ function ExpandableSection() {
         }
     }, [])
     return (
-        <VerticalList focusKey="expandable-list" onKeyPress={onExpandablePress}>
+        <VerticalList focusKey="expandable-list" onKeyPress={onExpandablePress} style={{ border: "1px solid blue" }}>
             <Item focusKey="expandable" />
             {expanded && (
                 <FocusLock focusKey="my-only-lock">

--- a/packages/strategy-demo/index.tsx
+++ b/packages/strategy-demo/index.tsx
@@ -50,7 +50,6 @@ render(
 )
 
 function App() {
-    const [selectedItem, setSelectedItem] = useState<string | null>(null)
     const [expanded, setExpanded] = useState(false)
 
     return (
@@ -61,6 +60,8 @@ function App() {
 }
 
 function AppBody() {
+    const [added, setAdded] = useState(false)
+    const toggleAdded = useCallback(() => setAdded(a => !a), [setAdded])
     return (
         <div
             style={{
@@ -68,6 +69,7 @@ function AppBody() {
                 flexDirection: "column",
             }}
         >
+            <button onClick={toggleAdded}>Add Dynami</button>
             <HorizontalList
                 focusKey="horizontal_list"
                 style={{ marginTop: "32px", marginLeft: "60px", display: "flex" }}
@@ -77,7 +79,7 @@ function AppBody() {
 
             <div style={{ marginTop: "94px" }}>
                 <VerticalList focusKey="vertical_list_1">
-                    <VerticalMainBody />
+                    <VerticalMainBody added={added} />
                 </VerticalList>
             </div>
         </div>
@@ -93,13 +95,14 @@ function HorizontalBody() {
     )
 }
 
-function VerticalMainBody() {
+function VerticalMainBody({ added }: { added: boolean }) {
     return (
         <>
             <Item focusKey="vertical_item_1" />
             <Item focusKey="vertical_item_2" />
             <Item focusKey="expandable" />
             <Item focusKey="third" />
+            {added && <Item focusKey="dynamically added" />}
             <HorizontalList
                 focusKey="horizontal_list"
                 style={{ marginTop: "16px", marginLeft: "60px", display: "flex" }}

--- a/packages/strategy-demo/index.tsx
+++ b/packages/strategy-demo/index.tsx
@@ -1,0 +1,122 @@
+import * as React from "react"
+import { useCallback, useState } from "react"
+import { render } from "react-dom"
+import { FocusManager, SunbeamProvider, KeyPressManager } from "../react-sunbeam"
+import Item from "./StyledFocusItem"
+import HorizontalList from "./HorizontalList"
+import VerticalList from "./VerticalList"
+// import FocusLock from "./FocusLock"
+import customStrategy from "./customStrategy"
+
+const focusManager = new FocusManager({
+    initialFocusPath: [
+        "#vertical#root_vertical",
+        "#vertical#vertical_list_1",
+        "#horizontal#horizontal_list",
+        "sub_horizontal_1",
+    ],
+    strategy: customStrategy,
+})
+const keyPressManager = new KeyPressManager()
+keyPressManager.addListener(event => {
+    switch (event.key) {
+        case "ArrowRight":
+            event.preventDefault()
+            focusManager.moveRight()
+            return
+
+        case "ArrowLeft":
+            event.preventDefault()
+            focusManager.moveLeft()
+            return
+
+        case "ArrowUp":
+            event.preventDefault()
+            focusManager.moveUp()
+            return
+
+        case "ArrowDown":
+            event.preventDefault()
+            focusManager.moveDown()
+            return
+    }
+})
+
+render(
+    <SunbeamProvider focusManager={focusManager} keyPressManager={keyPressManager}>
+        <App />
+    </SunbeamProvider>,
+    document.getElementById("app")
+)
+
+function App() {
+    const [selectedItem, setSelectedItem] = useState<string | null>(null)
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <VerticalList focusKey="root_vertical">
+            <AppBody />
+        </VerticalList>
+    )
+}
+
+function AppBody() {
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+            }}
+        >
+            <HorizontalList
+                focusKey="horizontal_list"
+                style={{ marginTop: "32px", marginLeft: "60px", display: "flex" }}
+            >
+                <HorizontalBody />
+            </HorizontalList>
+
+            <div style={{ marginTop: "94px" }}>
+                <VerticalList focusKey="vertical_list_1">
+                    <VerticalMainBody />
+                </VerticalList>
+            </div>
+        </div>
+    )
+}
+
+function HorizontalBody() {
+    return (
+        <>
+            <Item focusKey="horizontal_1" />
+            <Item focusKey="horizontal_2" />
+        </>
+    )
+}
+
+function VerticalMainBody() {
+    return (
+        <>
+            <Item focusKey="vertical_item_1" />
+            <Item focusKey="vertical_item_2" />
+            <Item focusKey="expandable" />
+            <Item focusKey="third" />
+            <HorizontalList
+                focusKey="horizontal_list"
+                style={{ marginTop: "16px", marginLeft: "60px", display: "flex" }}
+            >
+                <SubHorizontalBody />
+            </HorizontalList>
+            <Item focusKey="forth" />
+        </>
+    )
+}
+
+function SubHorizontalBody() {
+    return (
+        <>
+            <Item focusKey="sub_horizontal_1" />
+            <Item focusKey="sub_horizontal_2" />
+            <Item focusKey="sub_horizontal_3" />
+        </>
+    )
+}

--- a/packages/strategy-demo/package.json
+++ b/packages/strategy-demo/package.json
@@ -9,6 +9,7 @@
     "scripts": {
         "build": "parcel build index.html",
         "dev": "parcel index.html --port 1235",
+        "build:esnext": "tsc --outDir dist/esnext --module esnext --removeComments --target ES2020",
         "type-check": "tsc --noEmit"
     },
     "dependencies": {

--- a/packages/strategy-demo/package.json
+++ b/packages/strategy-demo/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "strategy-demo",
+    "version": "0.11.0",
+    "main": "index.js",
+    "repository": "git+https://github.com/wzrdzl/react-sunbeam.git",
+    "author": "Vladimir Guguiev <vladimir.guguiev@gmail.com>",
+    "license": "MIT",
+    "private": true,
+    "scripts": {
+        "build": "parcel build index.html",
+        "dev": "parcel index.html --port 1235",
+        "type-check": "tsc --noEmit"
+    },
+    "dependencies": {
+        "react": "^16.10.2",
+        "react-dom": "^16.10.2",
+        "react-sunbeam": "^0.11.0"
+    },
+    "devDependencies": {
+        "@types/react": "^16.9.5",
+        "@types/react-dom": "^16.9.1",
+        "parcel-bundler": "^1.12.4",
+        "typescript": "^3.6.4"
+    },
+    "browserslist": [
+        ">5%",
+        "not dead",
+        "not ie <= 11",
+        "not op_mini all"
+    ]
+}

--- a/packages/strategy-demo/tsconfig.json
+++ b/packages/strategy-demo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es2017",
+        "moduleResolution": "node",
+        "strict": true,
+        "sourceMap": true,
+        "jsx": "react"
+    },
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
I had several Requirements on a Focus Management solution and tried to imagine how I could build all of them on top of `react-sunbeam`.
The general Idea is to provide a custom strategy that allows to manipulate the way how the next focused node is found. The current way is slightly hacky, because it depends on focusKey prefixes, but I hope it shows the potential use cases.
In order to showcase all the capabilities I also added a new Demo

### Features 
- Navigate one dimensional List (Vertical / Horizontal)
- Listen to keyboard shortcuts on focused item (to expand a sublist)
- Lock Focus within specific section
- Disable Focusable components within a section (If they are hidden, but cant be unmounted due to Animation)
- Automatically Focus the first focusable child on mount

I am happy to discuss a better approach or how to expose a clean API to enable the same use cases.